### PR TITLE
Task.5-1 データベース周りの環境設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,8 +14,8 @@ default: &default
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password:
-  host: localhost
+  password: root
+  host: 127.0.0.1
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+
+services:
+  database:
+    restart: always
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-datavolume:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
+volumes:
+  mysql-datavolume:
+    driver: local


### PR DESCRIPTION
## 作業概要
Railsアプリからデータベースにアクセスするための調整

## 作業詳細
- docker-compose.ymlの新規作成
- database.ymlの修正

## 作業エラー対処メモ
- docker-compose up -d を実行した際にport is already allocatedエラーが発生
(1)docker-compose.ymlファイル内で設定しているポート番号3306を使っている
　 箇所を特定するために、sudo lsof -i:3306コマンドを実行
(2)該当箇所をkillコマンドで消去(ex.sudo kill 61002)
(3)再度、docker-compose up -dコマンドを実行
⇨無事起動

## 参考にしたURL
- データベースの環境構築 by Docker
https://freelance.cat-algorithm.com/setup-database-by-docker/
- docker-compose up -d をしたらport is already allocatedのエラーが出た
https://qiita.com/ruriabukawa/items/d66462d79e9d1495c1aa