### PR TITLE
Task. 7-2~3  api_controller の実装,記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::ApiController < ApplicationController
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ArticlesController < ApplicationController
+  def index
+    articles = Article.all
+    render json: articles
+  end
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,3 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
   attributes :id, :body, :title
+  belongs_to :user
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :body, :title
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :account, :name
 
-  has_many :articles, dependent: :destroy
+  has_many :articles
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :account, :name
+
+  has_many :articles, dependent: :destroy
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,18 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
     subject { get(api_v1_articles_path) }
+
     before do
-      create_list(:article,3)
+      create_list(:article, 3)
     end
 
     it "記事一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id","body","title"]
-      expect(response).to have_http_status(200)
+      expect(res[0].keys).to eq ["id", "body", "title"]
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /api/v1/articles" do
+    it "works! (now write some real specs)" do
+      get api_v1_articles_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
       expect(res[0].keys).to eq ["id", "body", "title", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "account", "name"]
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -2,8 +2,16 @@ require 'rails_helper'
 
 RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
-    it "works! (now write some real specs)" do
-      get api_v1_articles_path
+    subject { get(api_v1_articles_path) }
+    before do
+      create_list(:article,3)
+    end
+
+    it "記事一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id","body","title"]
       expect(response).to have_http_status(200)
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "body", "title"]
+      expect(res[0].keys).to eq ["id", "body", "title", "user"]
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
## 作業概要
- api_controllerの実装(/app/controllers/api/v1/api_controller.rb)
- 記事一覧の実装

## 作業詳細
- api_controllerの実装(コマンド：bundle exec rails g controller api/v1/api)
- articleのSerializer用ファイルの作成(コマンド：bundle exec rails g serializer article)
- article controllerの作成(コマンド：bundle exec rails g controller api/v1/articles)
- requestテストファイル作成(コマンド：bundle exec rails g rspec:integration api/v1/Article),内容実装
- bundle exec rubocop -a実行
- userのSerializer用ファイルの追加作成