### PR TITLE
Task. 9-4 既存 API の修正

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,4 +1,7 @@
 class Api::V1::ApiController < ApplicationController
   include DeviseTokenAuth::Concerns::SetUserByToken
 
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,7 +1,4 @@
 class Api::V1::ApiController < ApplicationController
   include DeviseTokenAuth::Concerns::SetUserByToken
 
-  def current_user
-    @current_user ||= User.first
-  end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: [:update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
     articles = Article.all

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -49,13 +49,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers){ current_user.create_new_auth_token }
 
     it "記事が作成できる" do
       expect { subject }.to change { Article.count }.by(1)
@@ -64,14 +62,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers){ current_user.create_new_auth_token }
 
     it "記事の更新ができる" do
       expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
@@ -82,13 +78,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let!(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    let(:headers){ current_user.create_new_auth_token }
 
     it "記事の削除ができる" do
       expect { subject }.to change { Article.count }.by(-1)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    let(:headers){ current_user.create_new_auth_token }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事が作成できる" do
       expect { subject }.to change { Article.count }.by(1)
@@ -67,7 +67,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     let(:params) { { article: attributes_for(:article) } }
     let(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    let(:headers){ current_user.create_new_auth_token }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事の更新ができる" do
       expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
@@ -82,7 +82,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     let!(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    let(:headers){ current_user.create_new_auth_token }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事の削除ができる" do
       expect { subject }.to change { Article.count }.by(-1)


### PR DESCRIPTION
## 作業概要
既存 APIの修正

## 作業詳細
- ダミーコード(current_userメソッド)削除
- devise_token_auth提供のメソッドの有効化(別名からの置き換え)
- ログイン済ユーザーのみに特定APIへのアクセス許可を設定
- headersを渡す形でのarticles_spec.rb修正
- bundle exec rubocop -a実行