### PR TITLE
Task. 11-1 Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,7 +2,7 @@ class Article < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
 
-  enum status: { draft: 0, published: 1 }
+  enum status: { draft: "draft", published: "published" }
 
   belongs_to :user
   has_many :comments, dependent: :destroy

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,6 +2,8 @@ class Article < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
 
+  enum status: { draft: 0, published: 1 }
+
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   include DeviseTokenAuth::Concerns::User
 
   validates :account, presence: true, uniqueness: true
-  #validates :name, presence: true
+  # validates :name, presence: true
 
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy

--- a/db/migrate/20200113115254_add_status_to_articles.rb
+++ b/db/migrate/20200113115254_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :integer
+  end
+end

--- a/db/migrate/20200113115254_add_status_to_articles.rb
+++ b/db/migrate/20200113115254_add_status_to_articles.rb
@@ -1,5 +1,5 @@
 class AddStatusToArticles < ActiveRecord::Migration[5.2]
   def change
-    add_column :articles, :status, :integer, default: 0, null: false
+    add_column :articles, :status, :string, default: "draft", null: false
   end
 end

--- a/db/migrate/20200113115254_add_status_to_articles.rb
+++ b/db/migrate/20200113115254_add_status_to_articles.rb
@@ -1,5 +1,5 @@
 class AddStatusToArticles < ActiveRecord::Migration[5.2]
   def change
-    add_column :articles, :status, :integer
+    add_column :articles, :status, :integer, default: 0, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_22_083606) do
+ActiveRecord::Schema.define(version: 2020_01_13_115254) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2019_11_22_083606) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2020_01_13_115254) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.integer "status", default: 0, null: false
+    t.string "status", default: "draft", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Article, type: :model do
     end
 
     context "body,title,下書きが設定されている場合" do
-      let(:article) { build(:article, status: 0) }
+      let(:article) { build(:article, status: "draft") }
       it "下書き設定した記事が作られる" do
         expect(article).to be_valid
         expect(article.status).to eq "draft"
@@ -18,7 +18,7 @@ RSpec.describe Article, type: :model do
     end
 
     context "body,title,公開が設定されている場合" do
-      let(:article) { build(:article, status: 1) }
+      let(:article) { build(:article, status: "published") }
       it "公開設定した記事が作られる" do
         expect(article).to be_valid
         expect(article.status).to eq "published"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe Article, type: :model do
         expect(article).to be_valid
       end
     end
+    context "body,title,下書きが設定されている場合" do
+      let(:article) { build(:article, status: 0) }
+      it "下書き設定した記事が作られる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+    context "body,title,公開が設定されている場合" do
+      let(:article) { build(:article, status: 1) }
+      it "公開設定した記事が作られる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
   end
 
   describe "異常系のテスト" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Article, type: :model do
         expect(article).to be_valid
       end
     end
+
     context "body,title,下書きが設定されている場合" do
       let(:article) { build(:article, status: 0) }
       it "下書き設定した記事が作られる" do
@@ -15,6 +16,7 @@ RSpec.describe Article, type: :model do
         expect(article.status).to eq "draft"
       end
     end
+
     context "body,title,公開が設定されている場合" do
       let(:article) { build(:article, status: 1) }
       it "公開設定した記事が作られる" do


### PR DESCRIPTION
## 作業概要
Article model に下書き機能を追加、テスト実装

## 作業詳細
- articlesテーブルにstatusカラムを追加,migrationファイルの修正,db:migrate実行
(コマンド：bundle exec rails g migration AddStatusToArticles status:integer) 
- modelにenum定義を追加
- テスト実装
- bundle exec rubocop -a実行