### PR TITLE
Task. 11-2 既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.all
+    articles = Article.where(status: "published")
     render json: articles
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.find_by(id: params[:id],status: "published")
     render json: article
   end
 
@@ -30,7 +30,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   private
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 
     def set_article

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.where(status: "published")
+    articles = Article.published
     render json: articles
   end
 
   def show
-    article = Article.find_by(id: params[:id],status: "published")
+    article = Article.published.find(params[:id])
     render json: article
   end
 

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,4 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     it "記事一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
+      binding.pry
       expect(res.length).to eq 3
       expect(res[0].keys).to eq ["id", "body", "title", "user"]
       expect(res[0]["user"].keys).to eq ["id", "account", "name"]

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     before do
-      create_list(:article, 3,status:"published")
+      create_list(:article, 3, status: "published")
     end
 
     it "公開設定にしている記事一覧が取得できる" do
@@ -22,7 +22,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定したidの記事が存在する場合" do
-      let(:article) { create(:article, status:"published") }
+      let(:article) { create(:article, status: "published") }
       let(:article_id) { article.id }
 
       it "記事の値が取得できる" do
@@ -49,7 +49,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
 
     context "記事が下書きの場合" do
-      let(:article) { create(:article, status:"draft") }
+      let(:article) { create(:article, status: "draft") }
       let(:article_id) { article.id }
 
       it "記事が見つからない" do
@@ -60,11 +60,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
+
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
     context "公開設定の場合" do
-      let(:params) { { article: attributes_for(:article, status:"published") } }
+      let(:params) { { article: attributes_for(:article, status: "published") } }
 
       it "公開設定の記事が作成できる" do
         expect { subject }.to change { Article.count }.by(1)
@@ -75,7 +76,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
 
     context "下書き設定の場合" do
-      let(:params) { { article: attributes_for(:article, status:"draft") } }
+      let(:params) { { article: attributes_for(:article, status: "draft") } }
 
       it "下書き設定の記事が作成できる" do
         expect { subject }.to change { Article.count }.by(1)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -5,15 +5,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     before do
-      create_list(:article, 3)
+      create_list(:article, 3,status:"published")
     end
 
-    it "記事一覧が取得できる" do
+    it "公開設定にしている記事一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
-      binding.pry
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "body", "title", "user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
       expect(res[0]["user"].keys).to eq ["id", "account", "name"]
       expect(response).to have_http_status(:ok)
     end
@@ -23,18 +22,18 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_article_path(article_id)) }
 
     context "指定したidの記事が存在する場合" do
-      let(:article) { create(:article) }
+      let(:article) { create(:article, status:"published") }
       let(:article_id) { article.id }
 
       it "記事の値が取得できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
-
         expect(res["id"]).to eq article.id
         expect(res["body"]).to eq article.body
         expect(res["title"]).to eq article.title
         expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "published"
         expect(res["user"]["id"]).to eq article.user.id
         expect(res["user"]["account"]).to eq article.user.account
         expect(res["user"]["name"]).to eq article.user.name


### PR DESCRIPTION
## 作業概要
下書き機能を考慮した既存APIの修正、テスト実装

## 作業詳細
- articles_controller.rbの修正(publishedのみ表示、statusの変更を許可)
- article_serializer.rbの修正(statusの出力を追加)
- テスト実装
- bundle exec rubocop -a実行